### PR TITLE
Extent support

### DIFF
--- a/lib/harfbuzz.rb
+++ b/lib/harfbuzz.rb
@@ -9,8 +9,9 @@ module Harfbuzz
   ffi_lib 'harfbuzz'
 
   typedef :pointer, :hb_destroy_func_t
-  typedef :uint32, :hb_codepoint_t
-  typedef :bool, :hb_bool_t
+  typedef :uint32,  :hb_codepoint_t
+  typedef :bool,    :hb_bool_t
+  typedef :int32,   :hb_position_t
 
   attach_function :hb_version_string, [], :string
   attach_function :hb_version, [:pointer, :pointer, :pointer], :void

--- a/lib/harfbuzz.rb
+++ b/lib/harfbuzz.rb
@@ -10,9 +10,11 @@ module Harfbuzz
 
   typedef :pointer, :hb_destroy_func_t
   typedef :uint32, :hb_codepoint_t
+  typedef :bool, :hb_bool_t
 
   attach_function :hb_version_string, [], :string
   attach_function :hb_version, [:pointer, :pointer, :pointer], :void
+  attach_function :hb_version_atleast, [:uint, :uint, :uint], :hb_bool_t
 
   def self.version_string
     hb_version_string
@@ -28,6 +30,10 @@ module Harfbuzz
       minor_ptr.read_uint,
       micro_ptr.read_uint,
     ]
+  end
+
+  def self.at_least_version(major, minor, micro)
+    hb_version_atleast(major, minor, micro)
   end
 
   MinimumHarfbuzzVersion = '1.0.4'

--- a/lib/harfbuzz/buffer.rb
+++ b/lib/harfbuzz/buffer.rb
@@ -2,7 +2,6 @@ module Harfbuzz
 
   typedef :pointer, :hb_buffer_t
   typedef :uint32, :hb_mask_t
-  typedef :int32, :hb_position_t
 
   class GlyphInfo < FFI::Struct
 


### PR DESCRIPTION
This adds support for font/glyph extents. Font extents were recently added in version 1.1.3 (which is very recent), so I added support for `hb_version_atleast` and wrapped those features in an if block. Glyph extents have been supported since 0.9.2 so should be ok for everyone.
