### PR TITLE
Add Windows Mingw support

### DIFF
--- a/harfbuzz.gemspec
+++ b/harfbuzz.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'minitest', '~> 5.16'
   s.add_development_dependency 'minitest-power_assert', '~> 0.3'
+
+  s.metadata['msys2_mingw_dependencies'] = 'harfbuzz'
 end

--- a/lib/harfbuzz.rb
+++ b/lib/harfbuzz.rb
@@ -7,16 +7,7 @@ module Harfbuzz
   extend FFI::Library
 
   lib_names = ['harfbuzz']
-
-  # Windows-specific logic
-  if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
-    lib_names.unshift('libharfbuzz-0')
-
-    if defined?(RubyInstaller::Runtime)
-      RubyInstaller::Runtime.add_dll_directory("#{RbConfig::CONFIG['prefix']}/msys64/mingw64/bin")
-    end
-  end
-
+  lib_names.unshift('libharfbuzz-0') if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
   ffi_lib(lib_names)
 
   typedef :pointer, :hb_destroy_func_t

--- a/lib/harfbuzz.rb
+++ b/lib/harfbuzz.rb
@@ -6,7 +6,18 @@ module Harfbuzz
 
   extend FFI::Library
 
-  ffi_lib 'harfbuzz'
+  lib_names = ['harfbuzz']
+
+  # Windows-specific logic
+  if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+    lib_names.unshift('libharfbuzz-0')
+
+    if defined?(RubyInstaller::Runtime)
+      RubyInstaller::Runtime.add_dll_directory("#{RbConfig::CONFIG['prefix']}/msys64/mingw64/bin")
+    end
+  end
+
+  ffi_lib(lib_names)
 
   typedef :pointer, :hb_destroy_func_t
   typedef :uint32,  :hb_codepoint_t


### PR DESCRIPTION
This line will cause the correct Mingw package to automatically install for Windows users. You can see a similar example here:

https://github.com/ruby/psych/blob/master/psych.gemspec#L80